### PR TITLE
Support AUTH

### DIFF
--- a/addinstanceform.php
+++ b/addinstanceform.php
@@ -44,6 +44,10 @@ class cachestore_redis_addinstance_form extends cachestore_addinstance_form {
         $form->addRule('server', get_string('required'), 'required');
         $form->setType('server', PARAM_TEXT);
 
+        $form->addElement('passwordunmask', 'password', get_string('password', 'cachestore_redis'));
+        $form->setType('password', PARAM_RAW);
+        $form->addHelpButton('password', 'password', 'cachestore_redis');
+
         $form->addElement('text', 'prefix', get_string('prefix', 'cachestore_redis'), array('size' => 16));
         $form->setType('prefix', PARAM_TEXT); // We set to text but we have a rule to limit to alphanumext.
         $form->addHelpButton('prefix', 'prefix', 'cachestore_redis');

--- a/lang/en/cachestore_redis.php
+++ b/lang/en/cachestore_redis.php
@@ -29,8 +29,14 @@ $string['pluginname'] = 'Redis';
 $string['server'] = 'Server';
 $string['server_help'] = 'This sets the hostname or IP address of the Redis server to use.';
 
+$string['password'] = 'Password';
+$string['password_help'] = 'This sets the password of the Redis server.';
+
 $string['test_server'] = 'Test Server';
 $string['test_server_desc'] = 'Redis server to use for testing.';
+
+$string['test_password'] = 'Test server password';
+$string['test_password_desc'] = 'Redis test server password.';
 
 $string['prefix'] = 'Key prefix';
 $string['prefix_help'] = 'This prefix is used for all key names on the Redis server.

--- a/settings.php
+++ b/settings.php
@@ -34,3 +34,12 @@ $settings->add(
     16
   )
 );
+
+$settings->add(
+    new admin_setting_configpasswordunmask(
+        'cachestore_redis/test_password',
+        get_string('test_password', 'cachestore_redis'),
+        get_string('test_password_desc', 'cachestore_redis'),
+        ''
+    )
+);


### PR DESCRIPTION
Partial backport of https://tracker.moodle.org/browse/MDL-58311 -- support password-protected Redis instances.